### PR TITLE
Fix link to http://esri.github.io/geofaker-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ A full-fledged client-side device location faker.
 
 Location: `/examples/browser/`
 
-The Geofaker web app can be used at [esri.github.io/geofaker-js](http://geoloqi.github.io/geofaker-js/).
+The Geofaker web app can be used at [esri.github.io/geofaker-js](http://esri.github.io/geofaker-js/).
 
 #### Command Line
 


### PR DESCRIPTION
It used to 404. Now it rules the roost.
