### PR TITLE
bump geotrigger-js to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Geofaker.js Changelog
 
+## master
+* bump geotrigger-js to v1.0.0
+
 ## v0.3.0
 * fix circle rendering in browser example (test for distance before geojson)
 * change namespace to `Geotrigger.Faker`, change project name on github and npm (**breaking change**)

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -65,7 +65,7 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet.draw/0.2.3/leaflet.draw.js"></script>
   <script src="//rawgithub.com/Esri/esri-leaflet/v0.0.1-beta.3/dist/esri-leaflet.js"></script>
-  <script src="//rawgithub.com/Esri/geotrigger-js/v0.1.5/geotrigger.js"></script>
+  <script src="//rawgithub.com/Esri/geotrigger-js/v1.0.0/geotrigger.min.js"></script>
   <script src="../../dist/browser/geotrigger-faker.js"></script>
   <script src="client.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Nate Goldman <ngoldman@esri.com>",
   "license": "Apache 2.0",
   "dependencies": {
-    "geotrigger-js": "~0.1.5"
+    "geotrigger-js": "~1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
(adds tracking headers for usage reporting)
